### PR TITLE
Refactor llm interface and tool calling

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -126,11 +126,19 @@ function formatGoogleRequest(config: LLMConfig, defaultModel: string): any {
             }
           }
         }
-        // Fallback: our Google adapter generates ids as `google_${name}_${timestamp}`
+        // Fallback: our Google adapter generates ids as `google_${name}_${timestamp}_${counter}`
+        // Extract the function name by trimming the last two underscore-delimited segments
         if (!functionName && msg.tool_call_id.startsWith('google_')) {
+          const prefixLen = 'google_'.length;
           const lastUnderscore = msg.tool_call_id.lastIndexOf('_');
-          if (lastUnderscore > 'google_'.length) {
-            functionName = msg.tool_call_id.substring('google_'.length, lastUnderscore);
+          if (lastUnderscore > prefixLen) {
+            const secondLastUnderscore = msg.tool_call_id.lastIndexOf('_', lastUnderscore - 1);
+            if (secondLastUnderscore > prefixLen) {
+              functionName = msg.tool_call_id.substring(prefixLen, secondLastUnderscore);
+            } else {
+              // Backward compatibility for older ids without counter suffix
+              functionName = msg.tool_call_id.substring(prefixLen, lastUnderscore);
+            }
           }
         }
       }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -25,11 +25,11 @@ export function validateToolResultMessage(message: Message, providerName?: Servi
     return; // Ollama doesn't support tools
   }
 
-  // Google doesn't provide real tool_call_ids, so we make it optional
+  // Google doesn't provide real tool_call_ids. Accept either tool_call_id (preferred for our unified API)
+  // or name (Google-native). The adapter will resolve name from tool_call_id when needed.
   if (providerName === 'google') {
-    // For Google, we'll require the function name to match tool results
-    if (!message.name) {
-      throw new Error('Tool result message for Google provider must have a function name');
+    if (!message.tool_call_id && !message.name) {
+      throw new Error('Tool result message for Google provider must include either tool_call_id or name');
     }
     return;
   }


### PR DESCRIPTION
Standardize Google tool calling to use `tool_call_id` internally and ensure consistent `tool_calls` in assistant messages to unify the LLM interface.

Google's tool calling API uses `name` to identify tool results, unlike other providers that use `tool_call_id`. This PR enhances the Google adapter to resolve `name` from `tool_call_id` for tool results and generates unique `tool_call_id`s for Google's function calls, aligning its behavior with the unified `ToolCall` interface. This also ensures Google responses consistently include `tool_calls` in assistant messages, matching other providers.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0232b96-660e-4013-8213-e24cf802549a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0232b96-660e-4013-8213-e24cf802549a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

