### PR TITLE
Review and refactor code

### DIFF
--- a/src/utils/streaming.ts
+++ b/src/utils/streaming.ts
@@ -16,18 +16,22 @@ export async function* parseSSEStream(reader: ReadableStreamDefaultReader<Uint8A
       if (done) break;
       
       buffer += decoder.decode(value, { stream: true });
+      // Normalize CRLF and split by LF
+      buffer = buffer.replace(/\r\n/g, '\n');
       const lines = buffer.split('\n');
       buffer = lines.pop() || '';
       
-      for (const line of lines) {
-        if (line.startsWith('data: ')) {
-          const data = line.slice(6);
+      for (const rawLine of lines) {
+        const line = rawLine.trimEnd();
+        // Allow both 'data:' and 'data: ' prefixes per SSE spec
+        if (line.startsWith('data:')) {
+          const data = line.slice(5).trimStart();
           if (data === '[DONE]') return;
-          if (data.trim()) yield data;
+          if (data) yield data;
         }
       }
     }
   } finally {
     reader.releaseLock();
   }
-} 
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -20,10 +20,8 @@ export function validateToolResultMessage(message: Message, providerName?: Servi
     throw new Error('Tool result message must have content');
   }
 
-  // For providers that don't support tool_call_id, skip this validation
-  if (providerName === 'ollama') {
-    return; // Ollama doesn't support tools
-  }
+  // Providers that do not rely on tool_call_id would be handled here.
+  // Note: Ollama is OpenAI-compatible in this library and DOES support tool_call_id.
 
   // Google doesn't provide real tool_call_ids. Accept either tool_call_id (preferred for our unified API)
   // or name (Google-native). The adapter will resolve name from tool_call_id when needed.
@@ -131,32 +129,8 @@ export function validateServiceConfig(config: ServiceConfig): void {
  * @param config - LLM configuration to validate
  */
 export function validateLLMConfig(config: any): void {
-  if (!config) {
-    throw new Error('Configuration is required');
-  }
-
-  if (!config.service) {
-    throw new Error('Service name is required');
-  }
-
-  if (!config.messages || !Array.isArray(config.messages)) {
-    throw new Error('Messages array is required');
-  }
-
-  if (config.messages.length === 0) {
-    throw new Error('At least one message is required');
-  }
-
-  // Validate message structure
-  for (const message of config.messages) {
-    if (!message.role) {
-      throw new Error('Each message must have a role');
-    }
-
-    if (!message.content && message.role !== 'tool_result' && !message.tool_calls) {
-      throw new Error('Each message must have content, tool_calls, or be a tool_result');
-    }
-  }
+  // Delegate to the stricter service config validation to avoid duplication
+  validateServiceConfig(config as ServiceConfig);
 }
 
 /**


### PR DESCRIPTION
Refactor streaming utility and validation logic to improve robustness and reduce duplication.

SSE parsing now handles CRLF and both `data:`/`data: ` forms, improving resilience. `validateLLMConfig` delegates to `validateServiceConfig` to avoid duplication, and `validateToolResultMessage` no longer incorrectly exempts Ollama, as it supports `tool_call_id` in this library's context.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a1b5473-bbb7-4bdd-b636-df4f89f46664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a1b5473-bbb7-4bdd-b636-df4f89f46664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

